### PR TITLE
[Refactor] Repository 구조 개선

### DIFF
--- a/src/main/java/com/ddd/graphql/domain/route/repository/RouteMongoRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/RouteMongoRepository.java
@@ -1,0 +1,36 @@
+package com.ddd.graphql.domain.route.repository;
+
+import com.ddd.graphql.domain.route.graphql.entity.Route;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class RouteMongoRepository implements RouteRepository {
+
+	private final RouteTemplate routeTemplate;
+
+	@Override
+	public Mono<Route> findById(String id) {
+		return routeTemplate.findById(id);
+	}
+
+	@Override
+	public Flux<Route> findAll() {
+		return routeTemplate.findAll();
+	}
+
+	@Override
+	public Mono<Route> findByName(String name) {
+		return routeTemplate.findByName(name);
+	}
+
+	@Override
+	public Flux<Route> findByStationId(String stationId) {
+		return routeTemplate.findByStationId(stationId);
+	}
+}

--- a/src/main/java/com/ddd/graphql/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/RouteRepository.java
@@ -1,22 +1,16 @@
 package com.ddd.graphql.domain.route.repository;
 
 import com.ddd.graphql.domain.route.graphql.entity.Route;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-import org.springframework.lang.NonNull;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface RouteRepository extends ReactiveMongoRepository<Route, String>, RouteTemplate {
+public interface RouteRepository {
 
-	@NonNull
-	@Override
-	Mono<Route> findById(@NonNull String id);
+	Mono<Route> findById(String id);
 
-	@NonNull
-	@Override
 	Flux<Route> findAll();
 
 	Mono<Route> findByName(String name);
 
-
+	Flux<Route> findByStationId(String stationId);
 }

--- a/src/main/java/com/ddd/graphql/domain/station/repository/StationMongoRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/StationMongoRepository.java
@@ -1,0 +1,32 @@
+package com.ddd.graphql.domain.station.repository;
+
+import com.ddd.graphql.domain.station.graphql.entity.Station;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class StationMongoRepository implements StationRepository {
+
+	private final StationReactiveMongoRepository stationReactiveMongoRepository;
+
+	@Override
+	public Mono<Station> findById(String id) {
+		return stationReactiveMongoRepository.findById(id);
+	}
+
+	@Override
+	public Flux<Station> findAll() {
+		return stationReactiveMongoRepository.findAll();
+	}
+
+	@Override
+	public Flux<Station> findByKeyword(String keyword) {
+		return stationReactiveMongoRepository.findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
+				keyword, keyword, keyword);
+	}
+}

--- a/src/main/java/com/ddd/graphql/domain/station/repository/StationReactiveMongoRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/StationReactiveMongoRepository.java
@@ -1,0 +1,11 @@
+package com.ddd.graphql.domain.station.repository;
+
+import com.ddd.graphql.domain.station.graphql.entity.Station;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Flux;
+
+public interface StationReactiveMongoRepository extends ReactiveMongoRepository<Station, String> {
+
+	Flux<Station> findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
+			String keyword, String keyword2, String keyword3);
+}

--- a/src/main/java/com/ddd/graphql/domain/station/repository/StationRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/StationRepository.java
@@ -1,17 +1,15 @@
 package com.ddd.graphql.domain.station.repository;
 
 import com.ddd.graphql.domain.station.graphql.entity.Station;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-public interface StationRepository extends ReactiveMongoRepository<Station, String>,
-		StationTemplate {
+public interface StationRepository {
 
-	Flux<Station> findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
-			String keyword, String keyword2, String keyword3);
+	Mono<Station> findById(String id);
 
-	default Flux<Station> findByKeyword(String keyword) {
-		return findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
-				keyword, keyword, keyword);
-	}
+	Flux<Station> findAll();
+
+	Flux<Station> findByKeyword(String keyword);
+
 }


### PR DESCRIPTION
Service에서는 Repository interface에 대해서만 의존성을 가지고, 구현체에 대해서는 의존성을 가지지 않습니다.

다른 DB를 사용하거나 ORM을 사용하지 않고 Mapper를 사용해도 Service 로직을 변경할 필요가 없게 했습니다. (DIP)