### PR TITLE
[Refactor] 비즈니스 로직 분리

### DIFF
--- a/src/main/java/com/ddd/graphql/domain/route/graphql/RouteMapper.java
+++ b/src/main/java/com/ddd/graphql/domain/route/graphql/RouteMapper.java
@@ -1,10 +1,12 @@
 package com.ddd.graphql.domain.route.graphql;
 
-import com.ddd.graphql.domain.route.graphql.entity.Route;
-import com.ddd.graphql.domain.route.graphql.entity.StationInfo;
 import com.ddd.graphql.domain.route.graphql.type.RouteType;
+import com.ddd.graphql.domain.route.repository.document.RouteDocument;
+import com.ddd.graphql.domain.route.service.Route;
 import com.ddd.graphql.domain.station.graphql.StationMapper;
 import com.ddd.graphql.domain.station.graphql.type.StationType;
+import com.ddd.graphql.domain.station.repository.document.StationDocumentInfo;
+import com.ddd.graphql.domain.station.service.StationInfo;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -18,16 +20,21 @@ import org.mapstruct.MappingConstants.ComponentModel;
 		StationMapper.class})
 public interface RouteMapper {
 
+	Route toRoute(RouteDocument routeDocument);
+
 	RouteType toRouteType(Route route);
 
-	default List<StationType> toStationTypes(List<StationInfo> stations) {
-		return Optional.ofNullable(stations).orElse(Collections.emptyList()).stream()
+	@Mapping(source = "stationDocument", target = "station")
+	StationInfo stationDocumentInfoToStationInfo(StationDocumentInfo stationDocumentInfo);
+
+	default List<StationType> toStationTypes(List<StationInfo> stationInfos) {
+		return Optional.ofNullable(stationInfos).orElse(Collections.emptyList()).stream()
 				.map(this::toStationType).filter(Objects::nonNull).sorted().toList();
 	}
 
+
 	default StationType toStationType(StationInfo stationInfo) {
-		return Optional.ofNullable(stationInfo.station())
-				.map(__ -> toStationTypeImpl(stationInfo))
+		return Optional.ofNullable(stationInfo.station()).map(__ -> toStationTypeImpl(stationInfo))
 				.orElse(null);
 	}
 

--- a/src/main/java/com/ddd/graphql/domain/route/graphql/entity/StationInfo.java
+++ b/src/main/java/com/ddd/graphql/domain/route/graphql/entity/StationInfo.java
@@ -1,9 +1,0 @@
-package com.ddd.graphql.domain.route.graphql.entity;
-
-import com.ddd.graphql.domain.station.graphql.entity.Station;
-import lombok.Builder;
-
-@Builder
-public record StationInfo(Station station, String stopTime) {
-
-}

--- a/src/main/java/com/ddd/graphql/domain/route/graphql/mutation/CreateRouteInput.java
+++ b/src/main/java/com/ddd/graphql/domain/route/graphql/mutation/CreateRouteInput.java
@@ -1,5 +1,0 @@
-package com.ddd.graphql.domain.route.graphql.mutation;
-
-public record CreateRouteInput() {
-
-}

--- a/src/main/java/com/ddd/graphql/domain/route/repository/RouteMongoRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/RouteMongoRepository.java
@@ -1,36 +1,36 @@
 package com.ddd.graphql.domain.route.repository;
 
-import com.ddd.graphql.domain.route.graphql.entity.Route;
+import com.ddd.graphql.domain.route.graphql.RouteMapper;
+import com.ddd.graphql.domain.route.service.Route;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class RouteMongoRepository implements RouteRepository {
 
 	private final RouteTemplate routeTemplate;
+	private final RouteMapper routeMapper;
 
 	@Override
 	public Mono<Route> findById(String id) {
-		return routeTemplate.findById(id);
+		return routeTemplate.findById(id).map(routeMapper::toRoute);
 	}
 
 	@Override
 	public Flux<Route> findAll() {
-		return routeTemplate.findAll();
+		return routeTemplate.findAll().map(routeMapper::toRoute);
 	}
 
 	@Override
 	public Mono<Route> findByName(String name) {
-		return routeTemplate.findByName(name);
+		return routeTemplate.findByName(name).map(routeMapper::toRoute);
 	}
 
 	@Override
 	public Flux<Route> findByStationId(String stationId) {
-		return routeTemplate.findByStationId(stationId);
+		return routeTemplate.findByStationId(stationId).map(routeMapper::toRoute);
 	}
 }

--- a/src/main/java/com/ddd/graphql/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/RouteRepository.java
@@ -1,6 +1,6 @@
 package com.ddd.graphql.domain.route.repository;
 
-import com.ddd.graphql.domain.route.graphql.entity.Route;
+import com.ddd.graphql.domain.route.service.Route;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/com/ddd/graphql/domain/route/repository/RouteTemplate.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/RouteTemplate.java
@@ -1,17 +1,17 @@
 package com.ddd.graphql.domain.route.repository;
 
-import com.ddd.graphql.domain.route.graphql.entity.Route;
+import com.ddd.graphql.domain.route.repository.document.RouteDocument;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface RouteTemplate {
 
-	Mono<Route> findById(String id);
+	Mono<RouteDocument> findById(String id);
 
-	Flux<Route> findAll();
+	Flux<RouteDocument> findAll();
 
-	Mono<Route> findByName(String name);
+	Mono<RouteDocument> findByName(String name);
 
-	Flux<Route> findByStationId(String stationId);
+	Flux<RouteDocument> findByStationId(String stationId);
 
 }

--- a/src/main/java/com/ddd/graphql/domain/route/repository/RouteTemplateImpl.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/RouteTemplateImpl.java
@@ -6,7 +6,7 @@ import static org.springframework.data.mongodb.core.aggregation.Aggregation.newA
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.unwind;
 import static org.springframework.data.mongodb.core.aggregation.LookupOperation.newLookup;
 
-import com.ddd.graphql.domain.route.graphql.entity.Route;
+import com.ddd.graphql.domain.route.repository.document.RouteDocument;
 import java.util.Collections;
 import java.util.LinkedList;
 import lombok.RequiredArgsConstructor;
@@ -29,95 +29,93 @@ import reactor.core.publisher.Mono;
 @Repository
 public class RouteTemplateImpl implements RouteTemplate {
 
+	private static final String STATION_COLLECTION_NAME = "stations";
+	private static final String DEPARTURE_STATION_LIST_NAME = "departureStations";
+	private static final String ARRIVAL_STATION_LIST_NAME = "arrivalStations";
+	private static final String STATION_DOCUMENT_NAME = "stationDocument";
 	private final ReactiveMongoTemplate mongoTemplate;
 
 	private static LinkedList<AggregationOperation> getStationPopulationOperations() {
 		LinkedList<AggregationOperation> aggregationOperations = new LinkedList<>();
 
-		UnwindOperation departureStationsUnwindOperation = unwind("departureStations", true);
-		LookupOperation departureLookupOperation = newLookup()
-				.from("stations")
-				.localField("departureStations.stationId")
-				.foreignField("_id")
-				.as("departureStations.station");
-		UnwindOperation departureStationsDocUnwindOperation = unwind("departureStations.station",
+		UnwindOperation departureStationsUnwindOperation = unwind(DEPARTURE_STATION_LIST_NAME,
 				true);
+		LookupOperation departureLookupOperation = newLookup().from(STATION_COLLECTION_NAME)
+				.localField(DEPARTURE_STATION_LIST_NAME + "." + "stationId").foreignField("_id")
+				.as(DEPARTURE_STATION_LIST_NAME + "." + STATION_DOCUMENT_NAME);
+		UnwindOperation departureStationsDocUnwindOperation = unwind(
+				DEPARTURE_STATION_LIST_NAME + "." + STATION_DOCUMENT_NAME, true);
 
-		GroupOperation departureGroupOperation = group("_id")
-				.first("name").as("name")
-				.push("departureStations").as("departureStations")
-				.first("arrivalStations").as("arrivalStations");
+		GroupOperation departureGroupOperation = group("_id").first("name").as("name")
+				.push(DEPARTURE_STATION_LIST_NAME).as(DEPARTURE_STATION_LIST_NAME)
+				.first(ARRIVAL_STATION_LIST_NAME).as(ARRIVAL_STATION_LIST_NAME);
 
-		UnwindOperation arrivalStationsUnwindOperation = unwind("arrivalStations", true);
-		LookupOperation arrivalLookupOperation = newLookup()
-				.from("stations")
-				.localField("arrivalStations.stationId")
-				.foreignField("_id")
-				.as("arrivalStations.station");
-		UnwindOperation arrivalStationsDocUnwindOperation = unwind("arrivalStations.station", true);
+		UnwindOperation arrivalStationsUnwindOperation = unwind(ARRIVAL_STATION_LIST_NAME, true);
+		LookupOperation arrivalLookupOperation = newLookup().from(STATION_COLLECTION_NAME)
+				.localField(ARRIVAL_STATION_LIST_NAME + ".stationId").foreignField("_id")
+				.as(ARRIVAL_STATION_LIST_NAME + "." + STATION_DOCUMENT_NAME);
+		UnwindOperation arrivalStationsDocUnwindOperation = unwind(
+				ARRIVAL_STATION_LIST_NAME + "." + STATION_DOCUMENT_NAME, true);
 
-		GroupOperation arrivalGroupOperation = group("_id")
-				.first("name").as("name")
-				.first("departureStations").as("departureStations")
-				.push("arrivalStations").as("arrivalStations");
+		GroupOperation arrivalGroupOperation = group("_id").first("name").as("name")
+				.first(DEPARTURE_STATION_LIST_NAME).as(DEPARTURE_STATION_LIST_NAME)
+				.push(ARRIVAL_STATION_LIST_NAME).as(ARRIVAL_STATION_LIST_NAME);
 
-		Collections.addAll(aggregationOperations,
-				departureStationsUnwindOperation,
-				departureLookupOperation,
-				departureStationsDocUnwindOperation,
-				departureGroupOperation,
-				arrivalStationsUnwindOperation,
-				arrivalLookupOperation,
-				arrivalStationsDocUnwindOperation,
-				arrivalGroupOperation
-		);
+		Collections.addAll(aggregationOperations, departureStationsUnwindOperation,
+				departureLookupOperation, departureStationsDocUnwindOperation,
+				departureGroupOperation, arrivalStationsUnwindOperation, arrivalLookupOperation,
+				arrivalStationsDocUnwindOperation, arrivalGroupOperation);
 
 		return aggregationOperations;
 	}
 
 	@Override
-	public Mono<Route> findById(String id) {
+	public Mono<RouteDocument> findById(String id) {
 		MatchOperation matchOperation = match(Criteria.where("_id").is(new ObjectId(id)));
 
 		LinkedList<AggregationOperation> aggregationOperations = getStationPopulationOperations();
 		aggregationOperations.addFirst(matchOperation);
 
-		TypedAggregation<Route> aggregation = newAggregation(Route.class, aggregationOperations);
+		TypedAggregation<RouteDocument> aggregation = newAggregation(RouteDocument.class,
+				aggregationOperations);
 
-		return Mono.from(mongoTemplate.aggregate(aggregation, Route.class));
+		return Mono.from(mongoTemplate.aggregate(aggregation, RouteDocument.class));
 	}
 
 	@Override
-	public Flux<Route> findAll() {
-		TypedAggregation<Route> aggregation = newAggregation(Route.class,
+	public Flux<RouteDocument> findAll() {
+		TypedAggregation<RouteDocument> aggregation = newAggregation(RouteDocument.class,
 				getStationPopulationOperations());
 
-		return mongoTemplate.aggregate(aggregation, Route.class);
+		return mongoTemplate.aggregate(aggregation, RouteDocument.class);
 	}
 
 	@Override
-	public Mono<Route> findByName(String name) {
+	public Mono<RouteDocument> findByName(String name) {
 		MatchOperation matchOperation = match(Criteria.where("name").is(name));
 
 		LinkedList<AggregationOperation> aggregationOperations = getStationPopulationOperations();
 		aggregationOperations.addFirst(matchOperation);
 
-		TypedAggregation<Route> aggregation = newAggregation(Route.class, aggregationOperations);
+		TypedAggregation<RouteDocument> aggregation = newAggregation(RouteDocument.class,
+				aggregationOperations);
 
-		return Mono.from(mongoTemplate.aggregate(aggregation, Route.class));
+		return Mono.from(mongoTemplate.aggregate(aggregation, RouteDocument.class));
 	}
 
 	@Override
-	public Flux<Route> findByStationId(String stationId) {
+	public Flux<RouteDocument> findByStationId(String stationId) {
 		MatchOperation matchOperation = match(
-				Criteria.where("departureStations.station._id").is(stationId)
-						.orOperator(Criteria.where("arrivalStations.station._id").is(stationId)));
+				Criteria.where(DEPARTURE_STATION_LIST_NAME + ".station._id").is(stationId)
+						.orOperator(Criteria.where(ARRIVAL_STATION_LIST_NAME + ".station._id")
+								.is(stationId)));
 
 		LinkedList<AggregationOperation> aggregationOperations = getStationPopulationOperations();
 		aggregationOperations.addFirst(matchOperation);
 
-		TypedAggregation<Route> aggregation = newAggregation(Route.class, aggregationOperations);
+		TypedAggregation<RouteDocument> aggregation = newAggregation(RouteDocument.class,
+				aggregationOperations);
 
-		return Flux.from(mongoTemplate.aggregate(aggregation, Route.class));
+		return Flux.from(mongoTemplate.aggregate(aggregation, RouteDocument.class));
 	}
 }

--- a/src/main/java/com/ddd/graphql/domain/route/repository/document/RouteDocument.java
+++ b/src/main/java/com/ddd/graphql/domain/route/repository/document/RouteDocument.java
@@ -1,5 +1,6 @@
-package com.ddd.graphql.domain.route.graphql.entity;
+package com.ddd.graphql.domain.route.repository.document;
 
+import com.ddd.graphql.domain.station.repository.document.StationDocumentInfo;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,11 +10,11 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "routes")
 @Getter
 @Builder
-public class Route {
+public class RouteDocument {
 
 	@Id
 	private String id;
 	private String name;
-	private List<StationInfo> departureStations;
-	private List<StationInfo> arrivalStations;
+	private List<StationDocumentInfo> departureStations;
+	private List<StationDocumentInfo> arrivalStations;
 }

--- a/src/main/java/com/ddd/graphql/domain/route/resolver/RouteQueryResolver.java
+++ b/src/main/java/com/ddd/graphql/domain/route/resolver/RouteQueryResolver.java
@@ -1,5 +1,6 @@
 package com.ddd.graphql.domain.route.resolver;
 
+import com.ddd.graphql.domain.route.graphql.RouteMapper;
 import com.ddd.graphql.domain.route.graphql.type.RouteType;
 import com.ddd.graphql.domain.route.service.RouteQueryService;
 import com.ddd.graphql.domain.station.graphql.type.StationType;
@@ -17,6 +18,7 @@ import reactor.core.publisher.Mono;
 public class RouteQueryResolver {
 
 	private final RouteQueryService routeQueryService;
+	private final RouteMapper routeMapper;
 
 	@QueryMapping
 	public Mono<RouteType> testRoute() {
@@ -51,22 +53,22 @@ public class RouteQueryResolver {
 
 	@QueryMapping
 	public Flux<RouteType> getRoutes() {
-		return routeQueryService.getRoutes();
+		return routeQueryService.getRoutes().map(routeMapper::toRouteType);
 	}
 
 	@QueryMapping
 	public Mono<RouteType> getRouteById(@Argument String id) {
-		return routeQueryService.getRouteById(id);
+		return routeQueryService.getRouteById(id).map(routeMapper::toRouteType);
 	}
 
 	@QueryMapping
 	public Mono<RouteType> getRouteByName(@Argument String name) {
-		return routeQueryService.getRouteByName(name);
+		return routeQueryService.getRouteByName(name).map(routeMapper::toRouteType);
 	}
 
 	@QueryMapping
 	public Flux<RouteType> getRoutesByStationId(@Argument String stationId) {
-		return routeQueryService.getRoutesByStationId(stationId);
+		return routeQueryService.getRoutesByStationId(stationId).map(routeMapper::toRouteType);
 	}
 
 }

--- a/src/main/java/com/ddd/graphql/domain/route/service/Route.java
+++ b/src/main/java/com/ddd/graphql/domain/route/service/Route.java
@@ -1,0 +1,11 @@
+package com.ddd.graphql.domain.route.service;
+
+import com.ddd.graphql.domain.station.service.StationInfo;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record Route(String id, String name, List<StationInfo> departureStations,
+					List<StationInfo> arrivalStations) {
+
+}

--- a/src/main/java/com/ddd/graphql/domain/route/service/RouteQueryService.java
+++ b/src/main/java/com/ddd/graphql/domain/route/service/RouteQueryService.java
@@ -1,17 +1,16 @@
 package com.ddd.graphql.domain.route.service;
 
-import com.ddd.graphql.domain.route.graphql.type.RouteType;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface RouteQueryService {
 
-	Flux<RouteType> getRoutes();
+	Flux<Route> getRoutes();
 
-	Mono<RouteType> getRouteById(String id);
+	Mono<Route> getRouteById(String id);
 
-	Mono<RouteType> getRouteByName(String name);
+	Mono<Route> getRouteByName(String name);
 
-	Flux<RouteType> getRoutesByStationId(String stationId);
+	Flux<Route> getRoutesByStationId(String stationId);
 }
 

--- a/src/main/java/com/ddd/graphql/domain/route/service/RouteQueryServiceImpl.java
+++ b/src/main/java/com/ddd/graphql/domain/route/service/RouteQueryServiceImpl.java
@@ -1,7 +1,5 @@
 package com.ddd.graphql.domain.route.service;
 
-import com.ddd.graphql.domain.route.graphql.RouteMapper;
-import com.ddd.graphql.domain.route.graphql.type.RouteType;
 import com.ddd.graphql.domain.route.repository.RouteRepository;
 import com.ddd.graphql.exception.RouteNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -14,29 +12,26 @@ import reactor.core.publisher.Mono;
 public class RouteQueryServiceImpl implements RouteQueryService {
 
 	private final RouteRepository routeRepository;
-	private final RouteMapper routeMapper;
 
 	@Override
-	public Flux<RouteType> getRoutes() {
-		return routeRepository.findAll().map(routeMapper::toRouteType);
+	public Flux<Route> getRoutes() {
+		return routeRepository.findAll();
 	}
 
 	@Override
-	public Mono<RouteType> getRouteById(String id) {
+	public Mono<Route> getRouteById(String id) {
 		return routeRepository.findById(id)
-				.switchIfEmpty(Mono.error(RouteNotFoundException::new))
-				.map(routeMapper::toRouteType);
+				.switchIfEmpty(Mono.error(RouteNotFoundException::new));
 	}
 
 	@Override
-	public Mono<RouteType> getRouteByName(String name) {
+	public Mono<Route> getRouteByName(String name) {
 		return routeRepository.findByName(name)
-				.switchIfEmpty(Mono.error(RouteNotFoundException::new))
-				.map(routeMapper::toRouteType);
+				.switchIfEmpty(Mono.error(RouteNotFoundException::new));
 	}
 
 	@Override
-	public Flux<RouteType> getRoutesByStationId(String stationId) {
-		return routeRepository.findByStationId(stationId).map(routeMapper::toRouteType);
+	public Flux<Route> getRoutesByStationId(String stationId) {
+		return routeRepository.findByStationId(stationId);
 	}
 }

--- a/src/main/java/com/ddd/graphql/domain/station/graphql/StationMapper.java
+++ b/src/main/java/com/ddd/graphql/domain/station/graphql/StationMapper.java
@@ -1,13 +1,16 @@
 package com.ddd.graphql.domain.station.graphql;
 
-import com.ddd.graphql.domain.station.graphql.entity.Station;
 import com.ddd.graphql.domain.station.graphql.type.StationType;
+import com.ddd.graphql.domain.station.repository.document.StationDocument;
+import com.ddd.graphql.domain.station.service.Station;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants.ComponentModel;
 
 @Mapper(componentModel = ComponentModel.SPRING, injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 public interface StationMapper {
+
+	Station toStation(StationDocument stationDocument);
 
 	StationType toStationType(Station station);
 }

--- a/src/main/java/com/ddd/graphql/domain/station/graphql/mutation/CreateStationInput.java
+++ b/src/main/java/com/ddd/graphql/domain/station/graphql/mutation/CreateStationInput.java
@@ -1,5 +1,0 @@
-package com.ddd.graphql.domain.station.graphql.mutation;
-
-public record CreateStationInput() {
-
-}

--- a/src/main/java/com/ddd/graphql/domain/station/repository/StationMongoRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/StationMongoRepository.java
@@ -1,6 +1,7 @@
 package com.ddd.graphql.domain.station.repository;
 
-import com.ddd.graphql.domain.station.graphql.entity.Station;
+import com.ddd.graphql.domain.station.graphql.StationMapper;
+import com.ddd.graphql.domain.station.service.Station;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
@@ -13,20 +14,21 @@ import reactor.core.publisher.Mono;
 public class StationMongoRepository implements StationRepository {
 
 	private final StationReactiveMongoRepository stationReactiveMongoRepository;
+	private final StationMapper stationMapper;
 
 	@Override
 	public Mono<Station> findById(String id) {
-		return stationReactiveMongoRepository.findById(id);
+		return stationReactiveMongoRepository.findById(id).map(stationMapper::toStation);
 	}
 
 	@Override
 	public Flux<Station> findAll() {
-		return stationReactiveMongoRepository.findAll();
+		return stationReactiveMongoRepository.findAll().map(stationMapper::toStation);
 	}
 
 	@Override
 	public Flux<Station> findByKeyword(String keyword) {
 		return stationReactiveMongoRepository.findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
-				keyword, keyword, keyword);
+				keyword, keyword, keyword).map(stationMapper::toStation);
 	}
 }

--- a/src/main/java/com/ddd/graphql/domain/station/repository/StationReactiveMongoRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/StationReactiveMongoRepository.java
@@ -1,11 +1,12 @@
 package com.ddd.graphql.domain.station.repository;
 
-import com.ddd.graphql.domain.station.graphql.entity.Station;
+import com.ddd.graphql.domain.station.repository.document.StationDocument;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import reactor.core.publisher.Flux;
 
-public interface StationReactiveMongoRepository extends ReactiveMongoRepository<Station, String> {
+public interface StationReactiveMongoRepository extends
+		ReactiveMongoRepository<StationDocument, String> {
 
-	Flux<Station> findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
+	Flux<StationDocument> findByNameContainsIgnoreCaseOrDescriptionContainsIgnoreCaseOrAddressContainsIgnoreCase(
 			String keyword, String keyword2, String keyword3);
 }

--- a/src/main/java/com/ddd/graphql/domain/station/repository/StationRepository.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/StationRepository.java
@@ -1,6 +1,6 @@
 package com.ddd.graphql.domain.station.repository;
 
-import com.ddd.graphql.domain.station.graphql.entity.Station;
+import com.ddd.graphql.domain.station.service.Station;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/com/ddd/graphql/domain/station/repository/document/StationDocument.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/document/StationDocument.java
@@ -1,4 +1,4 @@
-package com.ddd.graphql.domain.station.graphql.entity;
+package com.ddd.graphql.domain.station.repository.document;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "stations")
 @Getter
 @Builder
-public class Station {
+public class StationDocument {
 
 	@Id
 	private String id;

--- a/src/main/java/com/ddd/graphql/domain/station/repository/document/StationDocumentInfo.java
+++ b/src/main/java/com/ddd/graphql/domain/station/repository/document/StationDocumentInfo.java
@@ -1,0 +1,8 @@
+package com.ddd.graphql.domain.station.repository.document;
+
+import lombok.Builder;
+
+@Builder
+public record StationDocumentInfo(StationDocument stationDocument, String stopTime) {
+
+}

--- a/src/main/java/com/ddd/graphql/domain/station/resolver/StationQueryResolver.java
+++ b/src/main/java/com/ddd/graphql/domain/station/resolver/StationQueryResolver.java
@@ -1,5 +1,6 @@
 package com.ddd.graphql.domain.station.resolver;
 
+import com.ddd.graphql.domain.station.graphql.StationMapper;
 import com.ddd.graphql.domain.station.graphql.type.StationType;
 import com.ddd.graphql.domain.station.service.StationQueryService;
 import com.ddd.graphql.exception.StationNotFoundException;
@@ -15,7 +16,7 @@ import reactor.core.publisher.Mono;
 public class StationQueryResolver {
 
 	private final StationQueryService stationQueryService;
-
+	private final StationMapper stationMapper;
 
 	@QueryMapping
 	public Mono<StationType> testStation() {
@@ -37,17 +38,18 @@ public class StationQueryResolver {
 
 	@QueryMapping
 	public Flux<StationType> getStations() {
-		return stationQueryService.getStations();
+		return stationQueryService.getStations().map(stationMapper::toStationType);
 	}
 
 	@QueryMapping
 	public Mono<StationType> getStationById(@Argument String id) {
-		return stationQueryService.getStationById(id);
+		return stationQueryService.getStationById(id).map(stationMapper::toStationType);
 	}
 
 	@QueryMapping
 	public Flux<StationType> searchStationsByKeyword(@Argument String keyword) {
-		return stationQueryService.searchStationsByKeyword(keyword);
+		return stationQueryService.searchStationsByKeyword(keyword)
+				.map(stationMapper::toStationType);
 	}
 
 }

--- a/src/main/java/com/ddd/graphql/domain/station/service/Station.java
+++ b/src/main/java/com/ddd/graphql/domain/station/service/Station.java
@@ -1,0 +1,9 @@
+package com.ddd.graphql.domain.station.service;
+
+import lombok.Builder;
+
+@Builder
+public record Station(String id, String name, String description, String address, Double latitude,
+					  Double longitude, Boolean isDeparture) {
+
+}

--- a/src/main/java/com/ddd/graphql/domain/station/service/StationInfo.java
+++ b/src/main/java/com/ddd/graphql/domain/station/service/StationInfo.java
@@ -1,0 +1,8 @@
+package com.ddd.graphql.domain.station.service;
+
+import lombok.Builder;
+
+@Builder
+public record StationInfo(Station station, String stopTime) {
+
+}

--- a/src/main/java/com/ddd/graphql/domain/station/service/StationQueryService.java
+++ b/src/main/java/com/ddd/graphql/domain/station/service/StationQueryService.java
@@ -1,15 +1,14 @@
 package com.ddd.graphql.domain.station.service;
 
-import com.ddd.graphql.domain.station.graphql.type.StationType;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface StationQueryService {
 
-	Flux<StationType> getStations();
+	Flux<Station> getStations();
 
-	Mono<StationType> getStationById(String id);
+	Mono<Station> getStationById(String id);
 
-	Flux<StationType> searchStationsByKeyword(String keyword);
+	Flux<Station> searchStationsByKeyword(String keyword);
 
 }

--- a/src/main/java/com/ddd/graphql/domain/station/service/StationQueryServiceImpl.java
+++ b/src/main/java/com/ddd/graphql/domain/station/service/StationQueryServiceImpl.java
@@ -1,7 +1,5 @@
 package com.ddd.graphql.domain.station.service;
 
-import com.ddd.graphql.domain.station.graphql.StationMapper;
-import com.ddd.graphql.domain.station.graphql.type.StationType;
 import com.ddd.graphql.domain.station.repository.StationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,21 +11,20 @@ import reactor.core.publisher.Mono;
 public class StationQueryServiceImpl implements StationQueryService {
 
 	private final StationRepository stationRepository;
-	private final StationMapper stationMapper;
 
 	@Override
-	public Flux<StationType> getStations() {
-		return stationRepository.findAll().map(stationMapper::toStationType);
+	public Flux<Station> getStations() {
+		return stationRepository.findAll();
 	}
 
 	@Override
-	public Mono<StationType> getStationById(String id) {
-		return stationRepository.findById(id).map(stationMapper::toStationType);
+	public Mono<Station> getStationById(String id) {
+		return stationRepository.findById(id);
 	}
 
 	@Override
-	public Flux<StationType> searchStationsByKeyword(String keyword) {
-		return stationRepository.findByKeyword(keyword).map(stationMapper::toStationType);
+	public Flux<Station> searchStationsByKeyword(String keyword) {
+		return stationRepository.findByKeyword(keyword);
 	}
 
 }

--- a/src/main/java/com/ddd/graphql/exception/AdviceController.java
+++ b/src/main/java/com/ddd/graphql/exception/AdviceController.java
@@ -2,9 +2,9 @@ package com.ddd.graphql.exception;
 
 import graphql.GraphQLError;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
 import org.springframework.graphql.execution.ErrorType;
 import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
 import reactor.core.publisher.Mono;
 
 @ControllerAdvice


### PR DESCRIPTION
비즈니스 로직, 도메인을 외부 프레임워크와 분리

비즈니스 도메인 오브젝트는 비즈니스 도메인 이름을 그대로 사용,
-Type으로 끝나는 오브젝트는 응답 Graphql DTO,
-Document로 끝나는 오브젝트는 데이터베이스 매핑 오브젝트